### PR TITLE
🐛 상품 csv 업로드시 이미지 저장 누락 버그 수정

### DIFF
--- a/src/main/java/smu/nuda/domain/product/entity/ProductImage.java
+++ b/src/main/java/smu/nuda/domain/product/entity/ProductImage.java
@@ -36,4 +36,13 @@ public class ProductImage extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private ImageType type;
+
+    public static ProductImage create(Product product, String imageUrl, int sequence, ImageType type) {
+        ProductImage image = new ProductImage();
+        image.product = product;
+        image.imageUrl = imageUrl;
+        image.sequence = sequence;
+        image.type = type;
+        return image;
+    }
 }

--- a/src/main/java/smu/nuda/domain/product/service/ProductAdminService.java
+++ b/src/main/java/smu/nuda/domain/product/service/ProductAdminService.java
@@ -13,6 +13,8 @@ import smu.nuda.domain.brand.entity.Brand;
 import smu.nuda.domain.product.entity.Category;
 import smu.nuda.domain.product.entity.Product;
 import smu.nuda.domain.brand.repository.BrandRepository;
+import smu.nuda.domain.product.entity.ProductImage;
+import smu.nuda.domain.product.entity.enums.ImageType;
 import smu.nuda.domain.product.repository.CategoryRepository;
 import smu.nuda.domain.product.repository.ProductRepository;
 import smu.nuda.domain.product.validator.ProductCsvValidator;
@@ -80,6 +82,17 @@ public class ProductAdminService {
 
             if (!dryRun) {
                 em.persist(product);
+
+                if (row.thumbnailImg() != null && !row.thumbnailImg().isBlank()) {
+                    ProductImage thumbnail = ProductImage.create(
+                            product,
+                            row.thumbnailImg(),
+                            0,
+                            ImageType.MAIN
+                    );
+                    em.persist(thumbnail);
+                }
+
                 count++;
 
                 if (count % BATCH_SIZE == 0) {


### PR DESCRIPTION
## 📌 Summary

- closed #71

---

## ✏️ Changes

- batch insert시 csv의 `thumbnail_img` 필드 값을 `productImage` 엔티티로 저장하지 않아, 상품 상세조회시 빈 리스트를 응답함.
- 대량 업로드 로직에서 product를 persist 후 csv의 `thumbnail_img`가 빈 값이 아니라면 엔티티를 생성하도록 수정함.
- 운영환경과 데이터 마이그레이션을 위해 다음과 같이 sql문으로 수행 및 검증함.

<details>
<summary>product.thumbnail_img를 productImage 테이블로 마이그레이션</summary>

```sql
INSERT INTO product_image (
    id,
    product_id,
    image_url,
    sequence,
    type,
    created_at,
    updated_at
)
SELECT
    nextval('product_image_seq'),
    p.id,
    p.thumbnail_img,
    0,
    'MAIN',
    now(),
    now()
FROM product p
WHERE p.thumbnail_img IS NOT NULL
AND NOT EXISTS (
    SELECT 1
    FROM product_image pi
    WHERE pi.product_id = p.id
);
```

</details>

<details>
<summary>product.thumbnail_img는 있는데 productImage 테이블로 복사 누락된 건 조회</summary>

```sql
SELECT id, name, thumbnail_img
FROM product p
WHERE thumbnail_img IS NOT NULL
  AND NOT EXISTS (
      SELECT 1 FROM product_image pi
      WHERE pi.product_id = p.id AND pi.type = 'MAIN'
  );
```

</details>

<details>
<summary>이미지 url이 서로 다르게 들어간 건 조회</summary>

```sql
SELECT p.id, p.thumbnail_img, pi.image_url
FROM product p
JOIN product_image pi ON p.id = pi.product_id
WHERE pi.type = 'MAIN'
  AND p.thumbnail_img != pi.image_url;
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * CSV 배치 임포트 중 제품 썸네일 이미지 자동 저장 기능 추가
  * 제품 이미지 생성 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->